### PR TITLE
chore(MA-1228): Fix build number inconsistency

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+ *       @josephcarrington @tanya-gygi @firasaltayeb

--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -14,7 +14,7 @@ module Fastlane
       end
 
       # Returns the last tag in the repo, one can filter tags by specifying the parameter   
-      def self.fetch_last_tag
+      def self.fetch_last_tag(filter:)
         tag = nil
         git_cmd = "git tag -l --sort=-v:refname | head -n 1"  # Get the most recent tag
       

--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -13,20 +13,20 @@ module Fastlane
         input.nil? || input.empty?
       end
 
-      # Returns the last tag in the repo, one can filter tags by specifying the parameter
-      def self.fetch_last_tag(filter:)
+      # Returns the last tag in the repo, one can filter tags by specifying the parameter   
+      def self.fetch_last_tag
         tag = nil
-        git_cmd = "git tag -l --sort=-v:refname"
-        if filter == nil
-           filter =""
-        end
-        git_cmd = git_cmd + "| grep -iF '#{filter}' -m 1"
+        git_cmd = "git tag -l --sort=-v:refname | head -n 1"  # Get the most recent tag
+      
         begin
-          tag = Actions::sh(git_cmd)
+          tag = Actions::sh(git_cmd)  # Executes the command
         rescue FastlaneCore::Interface::FastlaneShellError
+          UI.error("Failed to fetch the latest git tag.")
         end
+      
         tag
       end
+      
       
       # Returns the new build number, by bumping the last git tag build number.
       def self.new_build_number(filter:)


### PR DESCRIPTION
This ticket will ensure that any version and/or build number update we make will be reflected in our other releases, whether prod, snapshot or debug.

<img width="1029" alt="Screenshot 2024-10-03 at 3 03 50 PM" src="https://github.com/user-attachments/assets/cd14dd45-a1a8-4eef-87f8-71e318eb6e5d">

<img width="623" alt="Screenshot 2024-10-03 at 12 11 22 PM" src="https://github.com/user-attachments/assets/b6f0cf6e-4782-43ff-90ca-95a4b75377af">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208468725348189